### PR TITLE
Add additional rabbitmq parameters in rabbitmq.yaml.example

### DIFF
--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -11,6 +11,30 @@
 #       If your service uses basic authentication, you can optionally
 #       specify a username and password that will be used in the check.
 #       (it's set to guest/guest by RabbitMQ on setup)
+#   $tag_families
+#       Tag queues "families" based on regex match
+#   $ssl_verify
+#       Skip verification of the RabbitMQ management web endpoint 
+#       SSL certificate 
+#   $nodes
+#   $nodes_regexes
+#       Specify the nodes to collect metrics on (up to 100 nodes).
+#       If you have less than 100 nodes, metrics will be collected on all nodes
+#       by default.
+#   $queues
+#   $queues_regexes
+#       Specify the queues to collect metrics on (up to 200 queues).
+#
+#       If you have less than 200 queues, metrics will be collected on all queues
+#       by default.
+#
+#       If vhosts are set, set queue names as `vhost_name/queue_name`
+#
+#       If `tag families` are enabled, the first capture group in the regex will
+#       be used as the queue_family tag
+#   $vhosts
+#       List of vhosts to monitor with service checks. By default, a list of all
+#       vhosts is fetched and each one will be checked using the aliveness API.
 #
 # Sample Usage:
 #
@@ -22,12 +46,28 @@
 #
 
 class datadog_agent::integrations::rabbitmq (
-  $url       = undef,
-  $username  = undef,
-  $password  = undef,
-  $queues    = undef,
-  $vhosts    = undef,
+  $url            = undef,
+  $username       = 'guest',
+  $password       = 'guest',
+  $ssl_verify     = true,
+  $tag_families   = false,
+  $nodes          = [],
+  $nodes_regexes  = [],
+  $queues         = [],
+  $queues_regexes = [],
+  $vhosts         = [],
 ) inherits datadog_agent::params {
+
+  validate_string($url)
+  validate_string($username)
+  validate_string($password)
+  validate_bool($ssl_verify)
+  validate_bool($tag_families)
+  validate_array($nodes)
+  validate_array($nodes_regexes)
+  validate_array($queues)
+  validate_array($queues_regexes)
+  validate_array($vhosts)
   include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/rabbitmq.yaml":
@@ -37,6 +77,6 @@ class datadog_agent::integrations::rabbitmq (
     mode    => '0600',
     content => template('datadog_agent/agent-conf.d/rabbitmq.yaml.erb'),
     require => Package[$datadog_agent::params::package_name],
-    notify  => Service[$datadog_agent::params::service_name]
+    notify  => Service[$datadog_agent::params::service_name],
   }
 }

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -21,11 +21,16 @@ describe 'datadog_agent::integrations::rabbitmq' do
   it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
 
   context 'with default parameters' do
-    it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: }) }
-    it { should contain_file(conf_file).without_content(%r{rabbitmq_user: }) }
-    it { should contain_file(conf_file).without_content(%r{rabbitmq_pass: }) }
-    it { should contain_file(conf_file).without_content(%r{queues: }) }
-    it { should contain_file(conf_file).without_content(%r{vhosts: }) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url:}) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_user: guest}) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: guest}) }
+    it { should contain_file(conf_file).with_content(%r{ssl_verify: true}) }
+    it { should contain_file(conf_file).with_content(%r{tag_families: false}) }
+    it { should contain_file(conf_file).without_content(%r{nodes:}) }
+    it { should contain_file(conf_file).without_content(%r{nodes_regexes:}) }
+    it { should contain_file(conf_file).without_content(%r{queues:}) }
+    it { should contain_file(conf_file).without_content(%r{queues_regexes:}) }
+    it { should contain_file(conf_file).without_content(%r{vhosts:}) }
   end
 
   context 'with parameters set' do
@@ -33,13 +38,23 @@ describe 'datadog_agent::integrations::rabbitmq' do
       url: 'http://rabbit1:15672/',
       username: 'foo',
       password: 'bar',
+      ssl_verify: false,
+      tag_families: true,
+      nodes: %w{ node1 node2 node3 },
+      nodes_regexes: %w{ ^regex1 regex2$ regex3* },
       queues: %w{ queue1 queue2 queue3 },
+      queues_regexes: %w{ ^regex4 regex5$ regex6* },
       vhosts: %w{ vhost1 vhost2 vhost3 },
     }}
     it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: http://rabbit1:15672/}) }
     it { should contain_file(conf_file).with_content(%r{rabbitmq_user: foo}) }
     it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: bar}) }
+    it { should contain_file(conf_file).with_content(%r{ssl_verify: false}) }
+    it { should contain_file(conf_file).with_content(%r{tag_families: true}) }
+    it { should contain_file(conf_file).with_content(%r{nodes:\s+- node1\s+- node2\s+- node3}) }
+    it { should contain_file(conf_file).with_content(%r{nodes_regexes:\s+- \^regex1\s+- regex2\$\s+- regex3\*}) }
     it { should contain_file(conf_file).with_content(%r{queues:\s+- queue1\s+- queue2\s+- queue3}) }
+    it { should contain_file(conf_file).with_content(%r{queues_regexes:\s+- \^regex4\s+- regex5\$\s+- regex6\*}) }
     it { should contain_file(conf_file).with_content(%r{vhosts:\s+- vhost1\s+- vhost2\s+- vhost3}) }
   end
 end

--- a/templates/agent-conf.d/rabbitmq.yaml.erb
+++ b/templates/agent-conf.d/rabbitmq.yaml.erb
@@ -2,22 +2,40 @@ init_config:
 
 instances:
     -  rabbitmq_api_url: <%= @url %>
-<% if @username -%>
        rabbitmq_user: <%= @username %>
-<% end -%>
-<% if @password -%>
        rabbitmq_pass: <%= @password %>
+       ssl_verify: <%= @ssl_verify %>
+       tag_families: <%= @tag_families %>
+
+<% unless @nodes.empty?  -%>
+       nodes:
+<% @nodes.each do |x| -%>
+         - <%= x %>
+<% end -%>
 <% end -%>
 
-<% if @queues  -%>
+<% unless @nodes_regexes.empty?  -%>
+       nodes_regexes:
+<% @nodes_regexes.each do |x| -%>
+         - <%= x %>
+<% end -%>
+<% end -%>
+
+<% unless @queues.empty?  -%>
        queues:
 <% @queues.each do |x| -%>
          - <%= x %>
 <% end -%>
 <% end -%>
 
+<% unless @queues_regexes.empty?  -%>
+       queues_regexes:
+<% @queues_regexes.each do |x| -%>
+         - <%= x %>
+<% end -%>
+<% end -%>
 
-<% if @vhosts -%>
+<% unless @vhosts.empty? -%>
        vhosts:
 <% @vhosts.each do |x| -%>
          - <%= x %>


### PR DESCRIPTION
In the Datadog integration examples, the RabbitMQ one (https://github.com/DataDog/dd-agent/blob/master/conf.d/rabbitmq.yaml.example) had some additional parameters not currently available in the Puppet module.

This PR covers a couple different changes:

    Adds the following parameters to the RabbitMQ template:
        ssl_verify
        tag_families
        nodes
        nodes_regexes
        queues_regexes

    Sets defaults according to the example file:

        username = 'guest'

        password = 'guest'

        ssl_verify = true

        tag_families = false

        While these defaults are implicitly being set in the checks, I thought it would be clearer for users if they saw it in Puppet to reflect what the python scripts are doing in places like (https://github.com/DataDog/dd-agent/blob/master/checks.d/rabbitmq.py#L114-L115)
        Additionally, because these defaults are set, we don't need to check them in the erb template.

    Add parameter validation to fail fast
